### PR TITLE
🦺 [Tech Debt] Update references to the archived Loafwallet repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Any jailbreak app can grant itself access to every other app's keychain data. Th
 2. Download and install the latest version of [Xcode](https://developer.apple.com/xcode/)
 3. Clone this repo & init submodules
 ```bash
-$ git clone https://github.com/litecoin-foundation/loafwallet-ios
+$ git clone https://github.com/litecoin-foundation/litewallet-ios
 $ git submodule init
 $ git submodule update
 ```

--- a/loafwallet/CardViewController.swift
+++ b/loafwallet/CardViewController.swift
@@ -29,7 +29,7 @@ class CardViewController: UIViewController {
     
     private func updateLoginStatusFromViewModel() {
          
-        // Bugfix: https://github.com/litecoin-foundation/loafwallet-ios/issues/175
+        // Bugfix:
         // Verifies the stack has only one VC and it is the UIHostingController
         
         DispatchQueue.main.async {

--- a/loafwallet/TransactionsViewController.swift
+++ b/loafwallet/TransactionsViewController.swift
@@ -221,7 +221,7 @@ class TransactionsViewController: UIViewController, UITableViewDelegate, UITable
                     self.present(hostingController, animated: true) {
                         
                         
-                        // Notes of bugfix: https://github.com/litecoin-foundation/loafwallet-ios/pull/247
+                        // Notes of bugfix: 
                         // Refactored the class to have two section and make sure the row never extends outside the transaction count.
                         
                         if indexPath.row < self.transactions.count {


### PR DESCRIPTION
## Why?

When moving the repo to `litewallet-ios` there are old reference to the old `loafwallet-ios` repo.

