### PR TITLE
🦺[TechDebt] - Update Support URL

### DIFF
--- a/loafwallet/src/Constants/Constants.swift
+++ b/loafwallet/src/Constants/Constants.swift
@@ -170,7 +170,8 @@ struct C {
     static let maxMemoLength = 250
     static let feedbackEmail = "feedback@litecoinfoundation.zendesk.com"
     static let supportEmail = "support@litecoinfoundation.zendesk.com"
-    
+    /// URL for LiteWallet support desk
+    static let litewalletSupportURL = "https://litewallet.io"
     
     static let reviewLink = "https://itunes.apple.com/app/loafwallet-litecoin-wallet/id1119332592?action=write-review"
     static var standardPort: Int {

--- a/loafwallet/src/ModalPresenter.swift
+++ b/loafwallet/src/ModalPresenter.swift
@@ -391,9 +391,7 @@ class ModalPresenter : Subscriber, Trackable {
         menu.didTapSupport = { [weak self, weak menu] in
             menu?.dismiss(animated: true, completion: {
                 
-                let urlString = "https://litecoinfoundation.zendesk.com/hc/en-us"
-                
-                guard let url = URL(string: urlString) else { return }
+                guard let url = URL(string: C.litewalletSupportURL) else { return }
                 
                 let vc = SFSafariViewController(url: url)
                 self?.topViewController?.present(vc, animated: true, completion: nil)


### PR DESCRIPTION
Updated to new URL (New URL site is not yet live.)

Because:
- We are switching the support URL to https://litewallet.io