### PR TITLE
🐞[Bug] version label was incorrectly formatted.

### DIFF
--- a/loafwallet/src/Constants/Constants.swift
+++ b/loafwallet/src/Constants/Constants.swift
@@ -261,5 +261,5 @@ struct C {
 struct AppVersion {
 	static let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
 	static let versionNumber = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-	static let string = "v." + versionNumber! + " (\(buildNumber!))"
+	static let string = "v" + versionNumber! + " (\(buildNumber!))"
 }


### PR DESCRIPTION
## Whats wrong?
User support ticket showed the bug.

Must be squashed