### PR TITLE
Fixed crash when using non-main thread to call SwiftUI

### DIFF
--- a/litewallet/ModalPresenter.swift
+++ b/litewallet/ModalPresenter.swift
@@ -36,7 +36,11 @@ class ModalPresenter: Subscriber, Trackable {
 	private func addSubscriptions() {
 		store.subscribe(self,
 		                selector: { $0.rootModal != $1.rootModal },
-		                callback: { self.presentModal($0.rootModal) })
+		                callback: { state in
+		                	Task { @MainActor in
+		                		self.presentModal(state.rootModal)
+		                	}
+		                })
 		store.subscribe(self,
 		                selector: { $0.alert != $1.alert && $1.alert != nil },
 		                callback: { self.handleAlertChange($0.alert) })

--- a/litewallet/StartFlowPresenter.swift
+++ b/litewallet/StartFlowPresenter.swift
@@ -29,7 +29,11 @@ class StartFlowPresenter: Subscriber {
 		                    selector: { $0.isLoginRequired != $1.isLoginRequired },
 		                    callback: { self.handleLoginRequiredChange(state: $0) })
 		store.subscribe(self, name: .lock,
-		                callback: { _ in self.presentLoginFlow(isPresentedForLock: true) })
+		                callback: { _ in
+		                	Task { @MainActor in
+		                		self.presentLoginFlow(isPresentedForLock: true)
+		                	}
+		                })
 	}
 
 	private func handleStartFlowChange(state: ReduxState) {


### PR DESCRIPTION
# Description
This PR contains bug fixes for:
 

##  Litewallet internal issues
- [14](https://github.com/litecoin-foundation/litewallet-engineering/issues/14)
- [15](https://github.com/litecoin-foundation/litewallet-engineering/issues/15)

It's because somehow SwiftUI is being called on a non-main thread.